### PR TITLE
Fix filter scrollbar display issues

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -266,6 +266,8 @@ body {
     gap: 16px;
     flex-wrap: wrap;
     justify-content: center;
+    align-items: center;
+    width: 100%;
 }
 
 .filter-group {
@@ -312,6 +314,7 @@ body {
     transition: all 0.2s ease;
     z-index: 1001;
     margin-top: 8px;
+    max-width: 200px;
 }
 
 .filter-group.active .filter-dropdown {
@@ -596,12 +599,25 @@ body {
     }
     
     .filters-container {
-        gap: 12px;
+        gap: 8px;
+        justify-content: flex-start;
+        overflow-x: auto;
+        overflow-y: hidden;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+        padding-bottom: 8px;
+    }
+    
+    .filters-container::-webkit-scrollbar {
+        display: none;
     }
     
     .filter-btn {
-        padding: 10px 12px;
+        padding: 8px 12px;
         font-size: 12px;
+        white-space: nowrap;
+        flex-shrink: 0;
     }
     
     .books-grid {
@@ -644,6 +660,21 @@ body {
         padding: 0 16px;
         max-width: 100%;
         overflow-x: hidden;
+    }
+    
+    .filters {
+        overflow-x: hidden;
+        width: 100%;
+    }
+    
+    .filter-dropdown {
+        max-width: 180px;
+        left: 50%;
+        transform: translateX(-50%) translateY(-10px);
+    }
+    
+    .filter-group.active .filter-dropdown {
+        transform: translateX(-50%) translateY(0);
     }
     
     .nav-container {


### PR DESCRIPTION
Make filters horizontally scrollable on mobile to fix horizontal overflow and scrollbar issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e0d205e-2cc8-42df-8da2-b03c541ce931">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e0d205e-2cc8-42df-8da2-b03c541ce931">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

