### PR TITLE
Remove filter scroll container on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,86 +69,78 @@
                         </button>
                     </div>
                     <button class="cta-btn">Sell Your Book</button>
-                </div>
-            </div>
-        </div>
-    </section>
+                    
+                    <div class="filters-container">
+                        <div class="filter-group">
+                            <button class="filter-btn dropdown-toggle">
+                                <i class="fas fa-book"></i>
+                                Genre
+                                <i class="fas fa-chevron-down"></i>
+                            </button>
+                            <div class="filter-dropdown">
+                                <a href="#" class="filter-option" data-filter="genre" data-value="">All Genres</a>
+                                <a href="#" class="filter-option" data-filter="genre" data-value="Fiction">Fiction</a>
+                                <a href="#" class="filter-option" data-filter="genre" data-value="Non-fiction">Non-fiction</a>
+                                <a href="#" class="filter-option" data-filter="genre" data-value="Science fiction">Science Fiction</a>
+                                <a href="#" class="filter-option" data-filter="genre" data-value="Mystery">Mystery</a>
+                                <a href="#" class="filter-option" data-filter="genre" data-value="Romance">Romance</a>
+                                <a href="#" class="filter-option" data-filter="genre" data-value="Biography">Biography</a>
+                                <a href="#" class="filter-option" data-filter="genre" data-value="History">History</a>
+                                <a href="#" class="filter-option" data-filter="genre" data-value="Children's literature">Children's</a>
+                            </div>
+                        </div>
 
-    <!-- Filters Section -->
-    <section class="filters">
-        <div class="container">
-            <div class="filters-container">
-                <div class="filter-group">
-                    <button class="filter-btn dropdown-toggle">
-                        <i class="fas fa-book"></i>
-                        Genre
-                        <i class="fas fa-chevron-down"></i>
-                    </button>
-                    <div class="filter-dropdown">
-                        <a href="#" class="filter-option" data-filter="genre" data-value="">All Genres</a>
-                        <a href="#" class="filter-option" data-filter="genre" data-value="Fiction">Fiction</a>
-                        <a href="#" class="filter-option" data-filter="genre" data-value="Non-fiction">Non-fiction</a>
-                        <a href="#" class="filter-option" data-filter="genre" data-value="Science fiction">Science Fiction</a>
-                        <a href="#" class="filter-option" data-filter="genre" data-value="Mystery">Mystery</a>
-                        <a href="#" class="filter-option" data-filter="genre" data-value="Romance">Romance</a>
-                        <a href="#" class="filter-option" data-filter="genre" data-value="Biography">Biography</a>
-                        <a href="#" class="filter-option" data-filter="genre" data-value="History">History</a>
-                        <a href="#" class="filter-option" data-filter="genre" data-value="Children's literature">Children's</a>
+                        <div class="filter-group">
+                            <button class="filter-btn dropdown-toggle">
+                                <i class="fas fa-language"></i>
+                                Language
+                                <i class="fas fa-chevron-down"></i>
+                            </button>
+                            <div class="filter-dropdown">
+                                <a href="#" class="filter-option" data-filter="language" data-value="">All Languages</a>
+                                <a href="#" class="filter-option" data-filter="language" data-value="eng">English</a>
+                                <a href="#" class="filter-option" data-filter="language" data-value="spa">Spanish</a>
+                                <a href="#" class="filter-option" data-filter="language" data-value="fre">French</a>
+                                <a href="#" class="filter-option" data-filter="language" data-value="ger">German</a>
+                                <a href="#" class="filter-option" data-filter="language" data-value="ita">Italian</a>
+                            </div>
+                        </div>
+
+                        <div class="filter-group">
+                            <button class="filter-btn dropdown-toggle">
+                                <i class="fas fa-calendar"></i>
+                                Year
+                                <i class="fas fa-chevron-down"></i>
+                            </button>
+                            <div class="filter-dropdown">
+                                <a href="#" class="filter-option" data-filter="year" data-value="">All Years</a>
+                                <a href="#" class="filter-option" data-filter="year" data-value="2020-2024">2020-2024</a>
+                                <a href="#" class="filter-option" data-filter="year" data-value="2010-2019">2010-2019</a>
+                                <a href="#" class="filter-option" data-filter="year" data-value="2000-2009">2000-2009</a>
+                                <a href="#" class="filter-option" data-filter="year" data-value="1990-1999">1990-1999</a>
+                                <a href="#" class="filter-option" data-filter="year" data-value="1980-1989">1980-1989</a>
+                                <a href="#" class="filter-option" data-filter="year" data-value="1900-1979">1900-1979</a>
+                            </div>
+                        </div>
+
+                        <div class="filter-group">
+                            <button class="filter-btn dropdown-toggle">
+                                <i class="fas fa-sort"></i>
+                                Sort
+                                <i class="fas fa-chevron-down"></i>
+                            </button>
+                            <div class="filter-dropdown">
+                                <a href="#" class="filter-option" data-filter="sort" data-value="relevance">Relevance</a>
+                                <a href="#" class="filter-option" data-filter="sort" data-value="rating">Highest Rated</a>
+                                <a href="#" class="filter-option" data-filter="sort" data-value="rating_asc">Lowest Rated</a>
+                                <a href="#" class="filter-option" data-filter="sort" data-value="title">Title A-Z</a>
+                                <a href="#" class="filter-option" data-filter="sort" data-value="author">Author A-Z</a>
+                                <a href="#" class="filter-option" data-filter="sort" data-value="date">Newest First</a>
+                                <a href="#" class="filter-option" data-filter="sort" data-value="date_asc">Oldest First</a>
+                            </div>
+                        </div>
                     </div>
                 </div>
-
-                <div class="filter-group">
-                    <button class="filter-btn dropdown-toggle">
-                        <i class="fas fa-language"></i>
-                        Language
-                        <i class="fas fa-chevron-down"></i>
-                    </button>
-                    <div class="filter-dropdown">
-                        <a href="#" class="filter-option" data-filter="language" data-value="">All Languages</a>
-                        <a href="#" class="filter-option" data-filter="language" data-value="eng">English</a>
-                        <a href="#" class="filter-option" data-filter="language" data-value="spa">Spanish</a>
-                        <a href="#" class="filter-option" data-filter="language" data-value="fre">French</a>
-                        <a href="#" class="filter-option" data-filter="language" data-value="ger">German</a>
-                        <a href="#" class="filter-option" data-filter="language" data-value="ita">Italian</a>
-                    </div>
-                </div>
-
-                <div class="filter-group">
-                    <button class="filter-btn dropdown-toggle">
-                        <i class="fas fa-calendar"></i>
-                        Year
-                        <i class="fas fa-chevron-down"></i>
-                    </button>
-                    <div class="filter-dropdown">
-                        <a href="#" class="filter-option" data-filter="year" data-value="">All Years</a>
-                        <a href="#" class="filter-option" data-filter="year" data-value="2020-2024">2020-2024</a>
-                        <a href="#" class="filter-option" data-filter="year" data-value="2010-2019">2010-2019</a>
-                        <a href="#" class="filter-option" data-filter="year" data-value="2000-2009">2000-2009</a>
-                        <a href="#" class="filter-option" data-filter="year" data-value="1990-1999">1990-1999</a>
-                        <a href="#" class="filter-option" data-filter="year" data-value="1980-1989">1980-1989</a>
-                        <a href="#" class="filter-option" data-filter="year" data-value="1900-1979">1900-1979</a>
-                    </div>
-                </div>
-
-                <div class="filter-group">
-                    <button class="filter-btn dropdown-toggle">
-                        <i class="fas fa-sort"></i>
-                        Sort
-                        <i class="fas fa-chevron-down"></i>
-                    </button>
-                    <div class="filter-dropdown">
-                        <a href="#" class="filter-option" data-filter="sort" data-value="relevance">Relevance</a>
-                        <a href="#" class="filter-option" data-filter="sort" data-value="rating">Highest Rated</a>
-                        <a href="#" class="filter-option" data-filter="sort" data-value="rating_asc">Lowest Rated</a>
-                        <a href="#" class="filter-option" data-filter="sort" data-value="title">Title A-Z</a>
-                        <a href="#" class="filter-option" data-filter="sort" data-value="author">Author A-Z</a>
-                        <a href="#" class="filter-option" data-filter="sort" data-value="date">Newest First</a>
-                        <a href="#" class="filter-option" data-filter="sort" data-value="date_asc">Oldest First</a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
 
     <!-- Books Section -->
     <section class="books-section">

--- a/index.html
+++ b/index.html
@@ -70,76 +70,80 @@
                     </div>
                     <button class="cta-btn">Sell Your Book</button>
                 </div>
-                
-                <!-- Filters moved here from separate section -->
-                <div class="filters-container">
-                    <div class="filter-group">
-                        <button class="filter-btn dropdown-toggle">
-                            <i class="fas fa-book"></i>
-                            Genre
-                            <i class="fas fa-chevron-down"></i>
-                        </button>
-                        <div class="filter-dropdown">
-                            <a href="#" class="filter-option" data-filter="genre" data-value="">All Genres</a>
-                            <a href="#" class="filter-option" data-filter="genre" data-value="Fiction">Fiction</a>
-                            <a href="#" class="filter-option" data-filter="genre" data-value="Non-fiction">Non-fiction</a>
-                            <a href="#" class="filter-option" data-filter="genre" data-value="Science fiction">Science Fiction</a>
-                            <a href="#" class="filter-option" data-filter="genre" data-value="Mystery">Mystery</a>
-                            <a href="#" class="filter-option" data-filter="genre" data-value="Romance">Romance</a>
-                            <a href="#" class="filter-option" data-filter="genre" data-value="Biography">Biography</a>
-                            <a href="#" class="filter-option" data-filter="genre" data-value="History">History</a>
-                            <a href="#" class="filter-option" data-filter="genre" data-value="Children's literature">Children's</a>
-                        </div>
-                    </div>
+            </div>
+        </div>
+    </section>
 
-                    <div class="filter-group">
-                        <button class="filter-btn dropdown-toggle">
-                            <i class="fas fa-language"></i>
-                            Language
-                            <i class="fas fa-chevron-down"></i>
-                        </button>
-                        <div class="filter-dropdown">
-                            <a href="#" class="filter-option" data-filter="language" data-value="">All Languages</a>
-                            <a href="#" class="filter-option" data-filter="language" data-value="eng">English</a>
-                            <a href="#" class="filter-option" data-filter="language" data-value="spa">Spanish</a>
-                            <a href="#" class="filter-option" data-filter="language" data-value="fre">French</a>
-                            <a href="#" class="filter-option" data-filter="language" data-value="ger">German</a>
-                            <a href="#" class="filter-option" data-filter="language" data-value="ita">Italian</a>
-                        </div>
+    <!-- Filters Section -->
+    <section class="filters">
+        <div class="container">
+            <div class="filters-container">
+                <div class="filter-group">
+                    <button class="filter-btn dropdown-toggle">
+                        <i class="fas fa-book"></i>
+                        Genre
+                        <i class="fas fa-chevron-down"></i>
+                    </button>
+                    <div class="filter-dropdown">
+                        <a href="#" class="filter-option" data-filter="genre" data-value="">All Genres</a>
+                        <a href="#" class="filter-option" data-filter="genre" data-value="Fiction">Fiction</a>
+                        <a href="#" class="filter-option" data-filter="genre" data-value="Non-fiction">Non-fiction</a>
+                        <a href="#" class="filter-option" data-filter="genre" data-value="Science fiction">Science Fiction</a>
+                        <a href="#" class="filter-option" data-filter="genre" data-value="Mystery">Mystery</a>
+                        <a href="#" class="filter-option" data-filter="genre" data-value="Romance">Romance</a>
+                        <a href="#" class="filter-option" data-filter="genre" data-value="Biography">Biography</a>
+                        <a href="#" class="filter-option" data-filter="genre" data-value="History">History</a>
+                        <a href="#" class="filter-option" data-filter="genre" data-value="Children's literature">Children's</a>
                     </div>
+                </div>
 
-                    <div class="filter-group">
-                        <button class="filter-btn dropdown-toggle">
-                            <i class="fas fa-calendar"></i>
-                            Year
-                            <i class="fas fa-chevron-down"></i>
-                        </button>
-                        <div class="filter-dropdown">
-                            <a href="#" class="filter-option" data-filter="year" data-value="">All Years</a>
-                            <a href="#" class="filter-option" data-filter="year" data-value="2020-2024">2020-2024</a>
-                            <a href="#" class="filter-option" data-filter="year" data-value="2010-2019">2010-2019</a>
-                            <a href="#" class="filter-option" data-filter="year" data-value="2000-2009">2000-2009</a>
-                            <a href="#" class="filter-option" data-filter="year" data-value="1990-1999">1990-1999</a>
-                            <a href="#" class="filter-option" data-filter="year" data-value="1980-1989">1980-1989</a>
-                            <a href="#" class="filter-option" data-filter="year" data-value="1900-1979">1900-1979</a>
-                        </div>
+                <div class="filter-group">
+                    <button class="filter-btn dropdown-toggle">
+                        <i class="fas fa-language"></i>
+                        Language
+                        <i class="fas fa-chevron-down"></i>
+                    </button>
+                    <div class="filter-dropdown">
+                        <a href="#" class="filter-option" data-filter="language" data-value="">All Languages</a>
+                        <a href="#" class="filter-option" data-filter="language" data-value="eng">English</a>
+                        <a href="#" class="filter-option" data-filter="language" data-value="spa">Spanish</a>
+                        <a href="#" class="filter-option" data-filter="language" data-value="fre">French</a>
+                        <a href="#" class="filter-option" data-filter="language" data-value="ger">German</a>
+                        <a href="#" class="filter-option" data-filter="language" data-value="ita">Italian</a>
                     </div>
+                </div>
 
-                    <div class="filter-group">
-                        <button class="filter-btn dropdown-toggle">
-                            <i class="fas fa-sort"></i>
-                            Sort
-                            <i class="fas fa-chevron-down"></i>
-                        </button>
-                        <div class="filter-dropdown">
-                            <a href="#" class="filter-option" data-filter="sort" data-value="relevance">Relevance</a>
-                            <a href="#" class="filter-option" data-filter="sort" data-value="rating">Highest Rated</a>
-                            <a href="#" class="filter-option" data-filter="sort" data-value="rating_asc">Lowest Rated</a>
-                            <a href="#" class="filter-option" data-filter="sort" data-value="title">Title A-Z</a>
-                            <a href="#" class="filter-option" data-filter="sort" data-value="author">Author A-Z</a>
-                            <a href="#" class="filter-option" data-filter="sort" data-value="date">Newest First</a>
-                            <a href="#" class="filter-option" data-filter="sort" data-value="date_asc">Oldest First</a>
-                        </div>
+                <div class="filter-group">
+                    <button class="filter-btn dropdown-toggle">
+                        <i class="fas fa-calendar"></i>
+                        Year
+                        <i class="fas fa-chevron-down"></i>
+                    </button>
+                    <div class="filter-dropdown">
+                        <a href="#" class="filter-option" data-filter="year" data-value="">All Years</a>
+                        <a href="#" class="filter-option" data-filter="year" data-value="2020-2024">2020-2024</a>
+                        <a href="#" class="filter-option" data-filter="year" data-value="2010-2019">2010-2019</a>
+                        <a href="#" class="filter-option" data-filter="year" data-value="2000-2009">2000-2009</a>
+                        <a href="#" class="filter-option" data-filter="year" data-value="1990-1999">1990-1999</a>
+                        <a href="#" class="filter-option" data-filter="year" data-value="1980-1989">1980-1989</a>
+                        <a href="#" class="filter-option" data-filter="year" data-value="1900-1979">1900-1979</a>
+                    </div>
+                </div>
+
+                <div class="filter-group">
+                    <button class="filter-btn dropdown-toggle">
+                        <i class="fas fa-sort"></i>
+                        Sort
+                        <i class="fas fa-chevron-down"></i>
+                    </button>
+                    <div class="filter-dropdown">
+                        <a href="#" class="filter-option" data-filter="sort" data-value="relevance">Relevance</a>
+                        <a href="#" class="filter-option" data-filter="sort" data-value="rating">Highest Rated</a>
+                        <a href="#" class="filter-option" data-filter="sort" data-value="rating_asc">Lowest Rated</a>
+                        <a href="#" class="filter-option" data-filter="sort" data-value="title">Title A-Z</a>
+                        <a href="#" class="filter-option" data-filter="sort" data-value="author">Author A-Z</a>
+                        <a href="#" class="filter-option" data-filter="sort" data-value="date">Newest First</a>
+                        <a href="#" class="filter-option" data-filter="sort" data-value="date_asc">Oldest First</a>
                     </div>
                 </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -711,22 +711,15 @@ body {
     .filters-container {
         gap: 8px;
         justify-content: flex-start;
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
-        scrollbar-width: none;
-        -ms-overflow-style: none;
+        flex-wrap: wrap;
         padding-bottom: 8px;
     }
     
-    .filters-container::-webkit-scrollbar {
-        display: none;
-    }
+
     
     .filter-btn {
         padding: 8px 12px;
         font-size: 12px;
-        white-space: nowrap;
-        flex-shrink: 0;
         min-height: 44px;
         display: flex;
         align-items: center;


### PR DESCRIPTION
Move filters out of the hero section and update mobile styles to prevent horizontal scrolling and enable natural wrapping.

Previously, filters were constrained within the hero section and styled with horizontal overflow, causing them to appear in a mini scroll container on mobile. This change ensures they flow naturally with the rest of the page content.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b545716-bebf-4aab-a407-ed9cfae9da12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b545716-bebf-4aab-a407-ed9cfae9da12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

